### PR TITLE
Travis CI builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ proto_doc/dbl_2_3/briefing_papers/SB01RFC.log
 # IDE artifacts
 .vscode
 sample.xpr
+
+# XML validate artifacts
+docs/schema/metadata.rng

--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,7 @@
+language: python
+# command to install dependencies
+install:
+  - pip install rnc2rng
+# command to run tests
+script:
+  - ./cibuild.sh

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Install the sphinx engine
 
     sudo apt-get install python-sphinx
 
-Then run the build script.
+Then run the build script from the docs/ directory.
 
 > NOTE: this top level makefile is just a shorcut to building the html.
 
@@ -102,3 +102,9 @@ Then run the build script.
 The docs are written in [reStructuredText](http://www.sphinx-doc.org/en/master/rest.html), processed by [Sphinx](http://www.sphinx-doc.org/en/master/index.html), and hosted online by [Read the Docs](https://readthedocs.org/).
 
 See the [reStructuredText Primer](http://www.sphinx-doc.org/en/master/rest.html) and the [Docutils reStructuredText Directives](http://docutils.sourceforge.net/docs/ref/rst/directives.html) documentation to learn how to use the syntax.
+
+## Validation
+
+There is a build script intended for a continuous integration system to run which validates the XML examples provided. You can run this locally but you first need to install the [rnc2rng](https://github.com/djc/rnc2rng) python package. You can do this by running `pip install rnc2rng`.
+
+Once dependencies are satisfied, you can `./cibuild.sh` and each file in the docs/examples/directory will be run through `xmllint` and checked against the schema.

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# This requires that the Python rnc2rng package be installed
+# pip3 install rnc2rng
+
+# Instructs bash to output all commands run and exit on any error
+set -xe
+
+# Ensure previous rng file is deleted
+rm -f docs/schema/metadata.rng
+
+# Build rng file from rnc master
+rnc2rng docs/schema/metadata.rnc >docs/schema/metadata.rng
+
+# Run xmllint on each example file
+for x in `ls docs/examples/*.xml`; do
+  xmllint --noout --relaxng docs/schema/metadata.rng $x
+done


### PR DESCRIPTION
This PR adds a continuous integration setup via Travis CI to run the `./cibuild` script which iterattes through the examples and validates them against the schema.

As noted in the readme, the script may also be run locally to validate the examples, currently there are some failures which I have purposes not fixed so that we can verify that they are caught when Travis CI runs the script.